### PR TITLE
fix(readme): Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A cool way to find common songs among friends and create playlists out of those 
 
 Currently, **Spotify** and **Apple Music** are supported.
 
-Website is available here at [sharedspotify.com](sharedspotify.com).
+Website is available here at [sharedspotify.com](https://sharedspotify.com).
 
 ## Support
 


### PR DESCRIPTION
Fixed incorrect hyperlink in readme

Current url from [commit](https://github.com/paulvidal/shared-spotify/commit/1417c3e960d41a229af8e9327d3dc66da5065e07) / [current master](https://github.com/paulvidal/shared-spotify/blob/master/README.md) is taking you to the [file tree](https://github.com/paulvidal/shared-spotify/blob/master/sharedspotify.com). So updating hyperlink to link to the actual website.